### PR TITLE
Chicken Scheme 5 egg build system port

### DIFF
--- a/allegro-c-util.scm
+++ b/allegro-c-util.scm
@@ -3,8 +3,8 @@
 <#
 
 (module allegro-c-util *
-	(import scheme chicken lolevel foreign)
-	
+	(import scheme (chicken base) (chicken foreign) (chicken gc) allegro)
+
 	(define (make-c-string-list* items)
 	  (if (list? items)
 	      (letrec ((malloc-list (foreign-lambda* (c-pointer (c-pointer char)) ((int count)) "C_return((char **)C_malloc(sizeof(char *) * (count + 1)));"))

--- a/allegro-glext.scm
+++ b/allegro-glext.scm
@@ -7,7 +7,11 @@
 <#
 
 (module allegro-glext *
-        (import scheme chicken foreign foreigners allegro)
-        
+        (import
+         scheme
+         (chicken base)
+         (chicken foreign)
+         allegro)
+
         (include "gl_ext_defs")
         (include "gl_ext_api"))

--- a/allegro.egg
+++ b/allegro.egg
@@ -1,0 +1,25 @@
+((license "BSD")
+ (category io)
+ (foreign-dependencies
+  liballegro5-dev
+  liballegro-acodec5-dev
+  liballegro-audio5-dev
+  liballegro-dialog5-dev
+  liballegro-image5-dev
+  liballegro-physfs5-dev
+  liballegro-ttf5-dev
+  liballegro-video5-dev)
+ (build-dependencies foreigners)
+ (author "Daniel J. Leslie")
+ (synopsis "Allegro")
+ (components
+  (extension allegro
+             (source-dependencies "acodec.scm" "altime.scm" "audio.scm" "base.scm" "bitmap_io.scm" "bitmap.scm" "color.scm" "config.scm" "constants.scm" "direct3d.scm" "display.scm" "enums.scm" "error.scm" "events.scm" "file.scm" "fixed.scm" "fmaths.scm" "font.scm" "fshook.scm" "image.scm" "joystick.scm" "keyboard.scm" "memfile.scm" "memory.scm" "mouse.scm" "opengl.scm" "path.scm" "physfs.scm" "primitives.scm" "system.scm" "threads.scm" "timer.scm" "tls.scm" "transformations.scm" "ttf.scm" "types.scm" "utf8.scm" "windows.scm")
+             (custom-build "build"))
+  (extension allegro-glext
+             (source-dependencies "gl_ext_api.scm" "gl_ext_defs.scm")
+             (custom-build "build")
+             (component-dependencies allegro))
+  (extension allegro-c-util
+             (custom-build "build")
+             (component-dependencies allegro))))

--- a/allegro.scm
+++ b/allegro.scm
@@ -14,7 +14,16 @@
 <#
 
 (module allegro *
-        (import scheme chicken foreign foreigners)
+
+        (import
+         scheme
+         (chicken base)
+         (chicken blob)
+         (chicken fixnum)
+         (chicken foreign)
+         (chicken gc)
+         (chicken platform)
+         foreigners)
 
         (include "types")
         (include "enums")
@@ -55,4 +64,4 @@
         (include "opengl")
         (include "primitives")
         (include "audio")
-	)
+	    )

--- a/build
+++ b/build
@@ -1,0 +1,18 @@
+# -*- sh -*-
+
+CFLAGS=`pkg-config --cflags allegro-5 allegro_image-5 allegro_primitives-5 allegro_color-5 allegro_dialog-5 allegro_main-5 allegro_physfs-5 allegro_font-5 allegro_ttf-5 allegro_audio-5 allegro_memfile-5 allegro_acodec-5 allegro_image-5`
+LDFLAGS=`pkg-config --libs allegro-5 allegro_image-5 allegro_primitives-5 allegro_color-5 allegro_dialog-5 allegro_main-5 allegro_physfs-5 allegro_font-5 allegro_ttf-5 allegro_audio-5 allegro_memfile-5 allegro_acodec-5 allegro_image-5`
+
+"$CHICKEN_CSC" -s -d1 -O3 -J -C "-O3 $CFLAGS" -L "$LDFLAGS" \
+               -Dhas-allegro-primitives \
+               -Dhas-allegro-color \
+               -Dhas-allegro-dialog \
+               -Dhas-allegro-main \
+               -Dhas-allegro-physfs \
+               -Dhas-allegro-font \
+               -Dhas-allegro-ttf \
+               -Dhas-allegro-audio \
+               -Dhas-allegro-memfile \
+               -Dhas-allegro-acodec \
+               -Dhas-allegro-image \
+               "$@"


### PR DESCRIPTION
I wrote the .egg & build files to be able to create the egg for Chicken Scheme 5. I did it mainly for my own use, but maybe you're interested in publishing it.

The build is not as adaptive : I assume the allegro version & the allegro components that are installed. Also I get lots of compilation warnings around GL extension and I was not able to test them in the absence of the opengl-glew egg.

Also, the source code itself is not backward compatible because I had to change the import of some core chicken librairies.